### PR TITLE
Refactor KonashiListener and KonashiEvent

### DIFF
--- a/Konashi/konashi-v2-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiNotifierTest.java
+++ b/Konashi/konashi-v2-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiNotifierTest.java
@@ -7,6 +7,7 @@ import com.uxxu.konashi.lib.events.KonashiConnectionEvent;
 import com.uxxu.konashi.lib.events.KonashiDeviceInfoEvent;
 import com.uxxu.konashi.lib.events.KonashiDigitalEvent;
 import com.uxxu.konashi.lib.events.KonashiUartEvent;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/Konashi/konashi-v2-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiNotifierTest.java
+++ b/Konashi/konashi-v2-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiNotifierTest.java
@@ -2,6 +2,12 @@ package com.uxxu.konashi.lib;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.uxxu.konashi.lib.events.KonashiAnalogEvent;
+import com.uxxu.konashi.lib.events.KonashiConnectionEvent;
+import com.uxxu.konashi.lib.events.KonashiDeviceInfoEvent;
+import com.uxxu.konashi.lib.events.KonashiDigitalEvent;
+import com.uxxu.konashi.lib.events.KonashiUartEvent;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -39,80 +45,80 @@ public class KonashiNotifierTest {
     public static class NotifyKonashiEventTest extends BaseTest {
         @Test
         public void callOnNotFoundPeripheral() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.PERIPHERAL_NOT_FOUND, null, null);
+            getNotifier().notifyKonashiEvent(KonashiConnectionEvent.PERIPHERAL_NOT_FOUND, null, null);
             Mockito.verify(getListner(), Mockito.times(1)).onNotFoundPeripheral();
         }
 
         @Test
         public void callOnConnected() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.CONNECTED, null, null);
+            getNotifier().notifyKonashiEvent(KonashiConnectionEvent.CONNECTED, null, null);
             Mockito.verify(getListner(), Mockito.times(1)).onConnected();
         }
 
         @Test
         public void callOnDisconnected() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.DISCONNECTED, null, null);
+            getNotifier().notifyKonashiEvent(KonashiConnectionEvent.DISCONNECTED, null, null);
             Mockito.verify(getListner(), Mockito.times(1)).onDisconnected();
         }
 
         @Test
         public void callOnReady() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.READY, null, null);
+            getNotifier().notifyKonashiEvent(KonashiConnectionEvent.READY, null, null);
             Mockito.verify(getListner(), Mockito.times(1)).onReady();
         }
 
         @Test
         public void callOnUpdatePioInput() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_PIO_INPUT, 0x01, null);
+            getNotifier().notifyKonashiEvent(KonashiDigitalEvent.UPDATE_PIO_INPUT, 0x01, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdatePioInput((byte) 0x01);
         }
 
         @Test
         public void callOnUpdateAnalogValue() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE, 0x01, 0xff);
+            getNotifier().notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE, 0x01, 0xff);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateAnalogValue(1, 255);
         }
 
         @Test
         public void callOnUpdateAnalogValueAio0() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO0, 0xff, null);
+            getNotifier().notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO0, 0xff, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateAnalogValueAio0(255);
         }
 
         @Test
         public void callOnUpdateAnalogValueAio1() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO1, 0xff, null);
+            getNotifier().notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO1, 0xff, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateAnalogValueAio1(255);
         }
 
         @Test
         public void callOnUpdateAnalogValueAio2() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO2, 0xff, null);
+            getNotifier().notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO2, 0xff, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateAnalogValueAio2(255);
         }
 
         @Test
         public void callOnCompleteUartRx() {
             byte[] data = "test".getBytes();
-            getNotifier().notifyKonashiEvent(KonashiEvent.UART_RX_COMPLETE, data, null);
+            getNotifier().notifyKonashiEvent(KonashiUartEvent.UART_RX_COMPLETE, data, null);
             Mockito.verify(getListner(), Mockito.times(1)).onCompleteUartRx(data);
         }
 
         @Test
         public void callOnUpdateBatteryLevel() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_BATTERY_LEVEL, 50, null);
+            getNotifier().notifyKonashiEvent(KonashiDeviceInfoEvent.UPDATE_BATTERY_LEVEL, 50, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateBatteryLevel(50);
         }
 
         @Test
         public void callOnUpdateSignalStrength() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.UPDATE_SIGNAL_STRENGTH, 25, null);
+            getNotifier().notifyKonashiEvent(KonashiDeviceInfoEvent.UPDATE_SIGNAL_STRENGTH, 25, null);
             Mockito.verify(getListner(), Mockito.times(1)).onUpdateSignalStrength(25);
         }
 
         @Test
         public void callOnCancelSelectKonashi() {
-            getNotifier().notifyKonashiEvent(KonashiEvent.CANCEL_SELECT_KONASHI, null, null);
+            getNotifier().notifyKonashiEvent(KonashiConnectionEvent.CANCEL_SELECT_KONASHI, null, null);
             Mockito.verify(getListner(), Mockito.times(1)).onCancelSelectKonashi();
         }
     }

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiApiInterface.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiApiInterface.java
@@ -3,6 +3,8 @@ package com.uxxu.konashi.lib;
 import android.app.Activity;
 import android.content.Context;
 
+import com.uxxu.konashi.lib.listeners.KonashiListener;
+
 /**
  * konashi APIのインタフェース
  * 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiBaseManager.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiBaseManager.java
@@ -24,13 +24,12 @@ import com.uxxu.konashi.lib.events.KonashiAnalogEvent;
 import com.uxxu.konashi.lib.events.KonashiConnectionEvent;
 import com.uxxu.konashi.lib.events.KonashiDeviceInfoEvent;
 import com.uxxu.konashi.lib.events.KonashiDigitalEvent;
+import com.uxxu.konashi.lib.events.KonashiEvent;
 import com.uxxu.konashi.lib.events.KonashiUartEvent;
 import com.uxxu.konashi.lib.ui.BleDeviceListAdapter;
 import com.uxxu.konashi.lib.ui.BleDeviceSelectionDialog;
 import com.uxxu.konashi.lib.ui.BleDeviceSelectionDialog.OnBleDeviceSelectListener;
 
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Timer;
 import java.util.TimerTask;

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiBaseManager.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiBaseManager.java
@@ -20,6 +20,11 @@ import android.widget.Toast;
 import com.uxxu.konashi.lib.entities.KonashiMessage;
 import com.uxxu.konashi.lib.entities.KonashiReadMessage;
 import com.uxxu.konashi.lib.entities.KonashiWriteMessage;
+import com.uxxu.konashi.lib.events.KonashiAnalogEvent;
+import com.uxxu.konashi.lib.events.KonashiConnectionEvent;
+import com.uxxu.konashi.lib.events.KonashiDeviceInfoEvent;
+import com.uxxu.konashi.lib.events.KonashiDigitalEvent;
+import com.uxxu.konashi.lib.events.KonashiUartEvent;
 import com.uxxu.konashi.lib.ui.BleDeviceListAdapter;
 import com.uxxu.konashi.lib.ui.BleDeviceSelectionDialog;
 import com.uxxu.konashi.lib.ui.BleDeviceSelectionDialog.OnBleDeviceSelectListener;
@@ -159,12 +164,12 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
                     
                     if(mKonashiName!=null){
                         // called findWithName. dispatch PERIPHERAL_NOT_FOUND event
-                        notifyKonashiEvent(KonashiEvent.PERIPHERAL_NOT_FOUND);
+                        notifyKonashiEvent(KonashiConnectionEvent.PERIPHERAL_NOT_FOUND);
                     } else {
                         mDialog.finishFinding();
                         
                         if(mBleDeviceListAdapter.getCount()==0){
-                            notifyKonashiEvent(KonashiEvent.PERIPHERAL_NOT_FOUND);
+                            notifyKonashiEvent(KonashiConnectionEvent.PERIPHERAL_NOT_FOUND);
                         }
                     }
                 }
@@ -371,7 +376,7 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
 
     @Override
     public void onCancelSelectingBleDevice() {
-        notifyKonashiEvent(KonashiEvent.CANCEL_SELECT_KONASHI);
+        notifyKonashiEvent(KonashiConnectionEvent.CANCEL_SELECT_KONASHI);
 
         if(mStatus.equals(BleStatus.SCANNING)){
             stopFindHandler();
@@ -398,7 +403,7 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
         KonashiUtils.log("konashi_status: " + mStatus.name());
 
         if (status == BleStatus.READY) {
-            notifyKonashiEvent(KonashiEvent.READY);
+            notifyKonashiEvent(KonashiConnectionEvent.READY);
         }
     }
     
@@ -471,14 +476,14 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
             if(newState == BluetoothProfile.STATE_CONNECTED){
                 setStatus(BleStatus.CONNECTED);
                 
-                notifyKonashiEvent(KonashiEvent.CONNECTED);
+                notifyKonashiEvent(KonashiConnectionEvent.CONNECTED);
                 
                 gatt.discoverServices();
             }
             else if(newState == BluetoothProfile.STATE_DISCONNECTED){
                 setStatus(BleStatus.DISCONNECTED);
                 
-                notifyKonashiEvent(KonashiEvent.DISCONNECTED);
+                notifyKonashiEvent(KonashiConnectionEvent.DISCONNECTED);
                 
                 mBluetoothGatt = null;
             }
@@ -773,7 +778,7 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
      * @param value PIO8bitで表現
      */
     protected void onUpdatePioInput(byte value){
-        notifyKonashiEvent(KonashiEvent.UPDATE_PIO_INPUT, value);
+        notifyKonashiEvent(KonashiDigitalEvent.UPDATE_PIO_INPUT, value);
     }
     
     /**
@@ -782,14 +787,14 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
      * @param value アナログ値
      */
     protected void onUpdateAnalogValue(int pin, int value){
-        notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE, pin, value);
+        notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE, pin, value);
         
         if(pin==Konashi.AIO0)
-            notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO0, value);
+            notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO0, value);
         else if(pin==Konashi.AIO1)
-            notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO1, value);
+            notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO1, value);
         else
-            notifyKonashiEvent(KonashiEvent.UPDATE_ANALOG_VALUE_AIO2, value);
+            notifyKonashiEvent(KonashiAnalogEvent.UPDATE_ANALOG_VALUE_AIO2, value);
     }
     
     /**
@@ -797,7 +802,7 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
      * @param data 受信データ
      */
     protected void onRecieveUart(byte[] data){
-        notifyKonashiEvent(KonashiEvent.UART_RX_COMPLETE, data);
+        notifyKonashiEvent(KonashiUartEvent.UART_RX_COMPLETE, data);
     }
 
 //     for konashi v1 (old codes)
@@ -810,7 +815,7 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
      * @param level バッテリー(%)
      */
     protected void onUpdateBatteryLevel(int level){
-        notifyKonashiEvent(KonashiEvent.UPDATE_BATTERY_LEVEL, level);
+        notifyKonashiEvent(KonashiDeviceInfoEvent.UPDATE_BATTERY_LEVEL, level);
     }
     
     /**
@@ -818,6 +823,6 @@ public class KonashiBaseManager implements BluetoothAdapter.LeScanCallback, OnBl
      * @param rssi 電波強度(db) 距離が近いと-40db, 距離が遠いと-90db程度になる
      */
     protected void onUpdateSignalSrength(int rssi){
-        notifyKonashiEvent(KonashiEvent.UPDATE_SIGNAL_STRENGTH, rssi);
+        notifyKonashiEvent(KonashiDeviceInfoEvent.UPDATE_SIGNAL_STRENGTH, rssi);
     }
 }

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiEvent.java
@@ -1,5 +1,7 @@
 package com.uxxu.konashi.lib;
 
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+
 /**
  * konashiのイベントたち
  * 
@@ -21,61 +23,6 @@ package com.uxxu.konashi.lib;
  * limitations under the License.
  * 
  */
-public enum KonashiEvent {
-    /**
-     * findWithNameで指定した名前のkonashiが見つからなかった時、もしくはまわりにBLEデバイスがなかった時
-     */
-    PERIPHERAL_NOT_FOUND,
-    /**
-     * BLEデバイス選択ダイアログをキャンセルした時
-     */
-    CANCEL_SELECT_KONASHI,
-    /**
-     * konashiに接続した時(まだこの時はkonashiが使える状態ではありません)
-     */
-    CONNECTED,
-    /**
-     * konashiとの接続を切断した時
-     */
-    DISCONNECTED,
-    /**
-     * konashiに接続完了した時(この時からkonashiにアクセスできるようになります)
-     */
-    READY,
-    /**
-     * PIOの入力の状態が変化した時
-     */
-    UPDATE_PIO_INPUT,
-    /**
-     * AIOのどれかのピンの電圧が取得できた時
-     */
-    UPDATE_ANALOG_VALUE,
-    /**
-     * AIO0の電圧が取得できた時
-     */
-    UPDATE_ANALOG_VALUE_AIO0,
-    /**
-     * AIO1の電圧が取得できた時
-     */
-    UPDATE_ANALOG_VALUE_AIO1,
-    /**
-     * AIO2の電圧が取得できた時
-     */
-    UPDATE_ANALOG_VALUE_AIO2,
-    /**
-     * I2Cからデータを受信した時
-     */
-    I2C_READ_COMPLETE,
-    /**
-     * UARTのRxからデータを受信した時
-     */
-    UART_RX_COMPLETE,
-    /**
-     * konashiのバッテリーのレベルを取得できた時
-     */
-    UPDATE_BATTERY_LEVEL,
-    /**
-     * konashiの電波強度を取得できた時
-     */
-    UPDATE_SIGNAL_STRENGTH
+public interface KonashiEvent {
+    void notify(Object param0, Object param1, KonashiBaseListener listener);
 }

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
@@ -1,5 +1,11 @@
 package com.uxxu.konashi.lib;
 
+import com.uxxu.konashi.lib.listeners.KonashiAnalogListener;
+import com.uxxu.konashi.lib.listeners.KonashiConnectionListener;
+import com.uxxu.konashi.lib.listeners.KonashiDeviceInfoListener;
+import com.uxxu.konashi.lib.listeners.KonashiDigitalListener;
+import com.uxxu.konashi.lib.listeners.KonashiUartListener;
+
 /**
  * konashiのイベントをキャッチするためのインタフェース
  *
@@ -21,65 +27,8 @@ package com.uxxu.konashi.lib;
  * limitations under the License.
  *
  */
-public interface KonashiListener {
-    /**
-     * findWithNameで指定した名前のkonashiが見つからなかった時、もしくはまわりにBLEデバイスがなかった時に呼ばれる
-     */
-    void onNotFoundPeripheral();
-    /**
-     * konashiに接続した時(まだこの時はkonashiが使える状態ではありません)に呼ばれる
-     */
-    void onConnected();
-    /**
-     * konashiとの接続を切断した時に呼ばれる
-     */
-    void onDisconnected();
-    /**
-     * konashiに接続完了した時(この時からkonashiにアクセスできるようになります)に呼ばれる
-     */
-    void onReady();
-    /**
-     * PIOの入力の状態が変化した時に呼ばれる
-     */
-    void onUpdatePioInput(byte value);
-    /**
-     * AIOのどれかのピンの電圧が取得できた時
-     */
-    void onUpdateAnalogValue(int pin, int value);
-    /**
-     * AIO0の電圧が取得できた時
-     */
-    void onUpdateAnalogValueAio0(int value);
-    /**
-     * AIO1の電圧が取得できた時
-     */
-    void onUpdateAnalogValueAio1(int value);
-    /**
-     * AIO2の電圧が取得できた時
-     */
-    void onUpdateAnalogValueAio2(int value);
-    /**
-     * UARTのRxからデータを受信した時
-     */
-    void onCompleteUartRx(byte[] data);
-    /**
-     * for konashi v1(old code)
-     */
-    //void onCompleteUartRx(byte data);
-    /**
-     * konashiのバッテリーのレベルを取得できた時
-     */
-    void onUpdateBatteryLevel(int level);
-    /**
-     * konashiの電波強度を取得できた時
-     */
-    void onUpdateSignalStrength(int rssi);
-    /**
-     * BLEデバイス選択ダイアログをキャンセルした時に呼ばれる
-     */
-    void onCancelSelectKonashi();
-    /**
-     * エラーが起きた時に呼ばれる
-     */
-    void onError(KonashiErrorReason errorReason, String message);
+public interface KonashiListener extends
+        KonashiConnectionListener, KonashiDeviceInfoListener,
+        KonashiAnalogListener, KonashiDigitalListener,
+        KonashiUartListener {
 }

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
@@ -2,7 +2,8 @@ package com.uxxu.konashi.lib;
 
 import android.content.Context;
 
-import java.util.ArrayList;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
+
 import java.util.List;
 
 /**

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
@@ -138,48 +138,7 @@ public class KonashiNotifier {
     }
 
     private void notifyKonashiEvent(KonashiEvent event, Object param0, Object param1, KonashiBaseListener listener) {
-        switch(event){
-            case PERIPHERAL_NOT_FOUND:
-                listener.onNotFoundPeripheral();
-                break;
-            case CONNECTED:
-                listener.onConnected();
-                break;
-            case DISCONNECTED:
-                listener.onDisconnected();
-                break;
-            case READY:
-                listener.onReady();
-                break;
-            case UPDATE_PIO_INPUT:
-                listener.onUpdatePioInput(Byte.valueOf(param0.toString()));
-                break;
-            case UPDATE_ANALOG_VALUE:
-                listener.onUpdateAnalogValue(Integer.valueOf(param0.toString()), Integer.valueOf(param1.toString()));
-                break;
-            case UPDATE_ANALOG_VALUE_AIO0:
-                listener.onUpdateAnalogValueAio0(Integer.valueOf(param0.toString()));
-                break;
-            case UPDATE_ANALOG_VALUE_AIO1:
-                listener.onUpdateAnalogValueAio1(Integer.valueOf(param0.toString()));
-                break;
-            case UPDATE_ANALOG_VALUE_AIO2:
-                listener.onUpdateAnalogValueAio2(Integer.valueOf(param0.toString()));
-                break;
-            case UART_RX_COMPLETE:
-                listener.onCompleteUartRx((byte[]) param0);
-                //observer.onCompleteUartRx(Byte.valueOf(param0.toString())); //for konashi v1(old code)
-                break;
-            case UPDATE_BATTERY_LEVEL:
-                listener.onUpdateBatteryLevel(Integer.valueOf(param0.toString()));
-                break;
-            case UPDATE_SIGNAL_STRENGTH:
-                listener.onUpdateSignalStrength(Integer.valueOf(param0.toString()));
-                break;
-            case CANCEL_SELECT_KONASHI:
-                listener.onCancelSelectKonashi();
-                break;
-        }
+        event.notify(param0, param1, listener);
     }
 
     private void notifyKonashiError(KonashiErrorReason errorReason, String cause, KonashiBaseListener listener) {

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
@@ -1,10 +1,9 @@
 package com.uxxu.konashi.lib;
 
+import com.uxxu.konashi.lib.events.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * konashiのイベントをKonashiObserverに伝えるクラス

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiNotifier.java
@@ -1,5 +1,7 @@
 package com.uxxu.konashi.lib;
 
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +31,7 @@ public class KonashiNotifier {
     /**
      * オブザーバたち
      */
-    private ArrayList<KonashiListener> mListeners = null;
+    private ArrayList<KonashiBaseListener> mListeners = null;
 
     /**
      * コンストラクタ
@@ -42,7 +44,7 @@ public class KonashiNotifier {
      * リスナーを追加する
      * @param listener 追加するリスナー
      */
-    public void addListener(KonashiListener listener){
+    public void addListener(KonashiBaseListener listener){
         if(!mListeners.contains(listener)){
             mListeners.add(listener);
         }
@@ -52,7 +54,7 @@ public class KonashiNotifier {
      * リスナーを削除する
      * @param listener 削除するリスナー
      */
-    public void removeListener(KonashiListener listener){
+    public void removeListener(KonashiBaseListener listener){
         if(mListeners.contains(listener)){
             mListeners.remove(listener);
         }
@@ -69,7 +71,7 @@ public class KonashiNotifier {
      * オブザーバを追加する
      * @param observer 追加するオブザーバ
      * @deprecated This method deprecated in 0.5.0.
-     * Use {@link #addListener(KonashiListener)} instead.
+     * Use {@link #addListener(KonashiBaseListener)} instead.
      */
     @Deprecated
     public void addObserver(KonashiObserver observer){
@@ -80,7 +82,7 @@ public class KonashiNotifier {
      * オブザーバを削除する
      * @param observer 削除するオブザーバ
      * @deprecated This method deprecated in 0.5.0.
-     * Use {@link #removeListener(KonashiListener)} instead.
+     * Use {@link #removeListener(KonashiBaseListener)} instead.
      */
     @Deprecated
     public void removeObserver(KonashiObserver observer){
@@ -102,7 +104,7 @@ public class KonashiNotifier {
      * @param event イベント名(KonashiEventだよっ）
      */
     public void notifyKonashiEvent(final KonashiEvent event, final Object param0, final Object param1){
-        for(final KonashiListener listener : mListeners){
+        for(final KonashiBaseListener listener : mListeners){
             final KonashiObserver observer = (listener instanceof KonashiObserver) ? (KonashiObserver) listener : null;
             if(observer != null && !observer.getActivity().isDestroyed()) {
                 observer.getActivity().runOnUiThread(new Runnable() {
@@ -120,7 +122,7 @@ public class KonashiNotifier {
     public void notifyKonashiError(final KonashiErrorReason errorReason){
         // 呼び出し元のメソッド名
         final String cause = errorReason.name() + " on " + new Throwable().getStackTrace()[2].getMethodName() + "()";
-        for(final KonashiListener listener : mListeners){
+        for(final KonashiBaseListener listener : mListeners){
             final KonashiObserver observer = (listener instanceof KonashiObserver) ? (KonashiObserver) listener : null;
             if(observer != null && !observer.getActivity().isDestroyed()) {
                 observer.getActivity().runOnUiThread(new Runnable() {
@@ -135,7 +137,7 @@ public class KonashiNotifier {
         }
     }
 
-    private void notifyKonashiEvent(KonashiEvent event, Object param0, Object param1, KonashiListener listener) {
+    private void notifyKonashiEvent(KonashiEvent event, Object param0, Object param1, KonashiBaseListener listener) {
         switch(event){
             case PERIPHERAL_NOT_FOUND:
                 listener.onNotFoundPeripheral();
@@ -180,7 +182,7 @@ public class KonashiNotifier {
         }
     }
 
-    private void notifyKonashiError(KonashiErrorReason errorReason, String cause, KonashiListener listener) {
+    private void notifyKonashiError(KonashiErrorReason errorReason, String cause, KonashiBaseListener listener) {
         listener.onError(errorReason, cause);
     }
 }

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiObserver.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiObserver.java
@@ -2,6 +2,8 @@ package com.uxxu.konashi.lib;
 
 import android.app.Activity;
 
+import com.uxxu.konashi.lib.listeners.KonashiListener;
+
 /**
  * konashiのイベントをキャッチするためのオブザーバクラス
  * @deprecated This class deprecated in 0.5.0.

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
@@ -1,7 +1,6 @@
 package com.uxxu.konashi.lib.events;
 
 import com.uxxu.konashi.lib.KonashiEvent;
-import com.uxxu.konashi.lib.KonashiListener;
 import com.uxxu.konashi.lib.listeners.KonashiAnalogListener;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
@@ -1,0 +1,60 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.KonashiListener;
+import com.uxxu.konashi.lib.listeners.KonashiAnalogListener;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public enum KonashiAnalogEvent implements KonashiEvent {
+    /**
+     * AIOのどれかのピンの電圧が取得できた時
+     */
+    UPDATE_ANALOG_VALUE {
+        @Override
+        public void notifyAnalogEvent(Object param0, Object param1, KonashiAnalogListener listener) {
+            listener.onUpdateAnalogValue(
+                    Integer.valueOf(param0.toString()),
+                    Integer.valueOf(param1.toString())
+            );
+        }
+    },
+    /**
+     * AIO0の電圧が取得できた時
+     */
+    UPDATE_ANALOG_VALUE_AIO0 {
+        @Override
+        public void notifyAnalogEvent(Object param0, Object param1, KonashiAnalogListener listener) {
+            listener.onUpdateAnalogValueAio0(Integer.valueOf(param0.toString()));
+        }
+    },
+    /**
+     * AIO1の電圧が取得できた時
+     */
+    UPDATE_ANALOG_VALUE_AIO1 {
+        @Override
+        protected void notifyAnalogEvent(Object param0, Object param1, KonashiAnalogListener listener) {
+            listener.onUpdateAnalogValueAio1(Integer.valueOf(param0.toString()));
+        }
+    },
+    /**
+     * AIO2の電圧が取得できた時
+     */
+    UPDATE_ANALOG_VALUE_AIO2 {
+        @Override
+        protected void notifyAnalogEvent(Object param0, Object param1, KonashiAnalogListener listener) {
+            listener.onUpdateAnalogValueAio2(Integer.valueOf(param0.toString()));
+        }
+    };
+
+    abstract protected void notifyAnalogEvent(Object param0, Object param1, KonashiAnalogListener listener);
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        if (listener instanceof KonashiAnalogListener) {
+            notifyAnalogEvent(param0, param1, (KonashiAnalogListener) listener);
+        }
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiAnalogEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiAnalogListener;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiConnectionEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiConnectionEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 import com.uxxu.konashi.lib.listeners.KonashiConnectionListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiConnectionEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiConnectionEvent.java
@@ -1,0 +1,65 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+import com.uxxu.konashi.lib.listeners.KonashiConnectionListener;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public enum KonashiConnectionEvent implements KonashiEvent {
+    /**
+     * findWithNameで指定した名前のkonashiが見つからなかった時、もしくはまわりにBLEデバイスがなかった時
+     */
+    PERIPHERAL_NOT_FOUND {
+        @Override
+        public void notifyConnectionEvent(KonashiConnectionListener listener) {
+            listener.onNotFoundPeripheral();
+        }
+    },
+    /**
+     * BLEデバイス選択ダイアログをキャンセルした時
+     */
+    CANCEL_SELECT_KONASHI {
+        @Override
+        public void notifyConnectionEvent(KonashiConnectionListener listener) {
+            listener.onCancelSelectKonashi();
+        }
+    },
+    /**
+     * konashiに接続完了した時(この時からkonashiにアクセスできるようになります)
+     */
+    READY {
+        @Override
+        public void notifyConnectionEvent(KonashiConnectionListener listener) {
+            listener.onReady();
+        }
+    },
+    /**
+     * konashiに接続した時(まだこの時はkonashiが使える状態ではありません)
+     */
+    CONNECTED {
+        @Override
+        public void notifyConnectionEvent(KonashiConnectionListener listener) {
+            listener.onConnected();
+        }
+    },
+    /**
+     * konashiとの接続を切断した時
+     */
+    DISCONNECTED {
+        @Override
+        public void notifyConnectionEvent(KonashiConnectionListener listener) {
+            listener.onDisconnected();
+        }
+    };
+
+    abstract protected void notifyConnectionEvent(KonashiConnectionListener listener);
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        if (listener instanceof KonashiConnectionListener) {
+            notifyConnectionEvent((KonashiConnectionListener) listener);
+        }
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDeviceInfoEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDeviceInfoEvent.java
@@ -1,0 +1,38 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+import com.uxxu.konashi.lib.listeners.KonashiDeviceInfoListener;
+
+/**
+ * Created by izumin on 8/7/15.
+ */
+public enum KonashiDeviceInfoEvent implements KonashiEvent {
+    /**
+     * konashiのバッテリーのレベルを取得できた時
+     */
+    UPDATE_BATTERY_LEVEL {
+        @Override
+        public void notifyDeviceInfoEvent(Object param, KonashiDeviceInfoListener listener) {
+            listener.onUpdateBatteryLevel(Integer.valueOf(param.toString()));
+        }
+    },
+    /**
+     * konashiの電波強度を取得できた時
+     */
+    UPDATE_SIGNAL_STRENGTH {
+        @Override
+        public void notifyDeviceInfoEvent(Object param, KonashiDeviceInfoListener listener) {
+            listener.onUpdateSignalStrength(Integer.valueOf(param.toString()));
+        }
+    };
+
+    abstract protected void notifyDeviceInfoEvent(Object param0, KonashiDeviceInfoListener listener);
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        if (listener instanceof KonashiDeviceInfoListener) {
+            notifyDeviceInfoEvent(param0, (KonashiDeviceInfoListener) listener);
+        }
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDeviceInfoEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDeviceInfoEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 import com.uxxu.konashi.lib.listeners.KonashiDeviceInfoListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDigitalEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDigitalEvent.java
@@ -1,0 +1,29 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+import com.uxxu.konashi.lib.listeners.KonashiDigitalListener;
+
+/**
+ * Created by izumin on 8/7/15.
+ */
+public enum KonashiDigitalEvent implements KonashiEvent {
+    /**
+     * PIOの入力の状態が変化した時
+     */
+    UPDATE_PIO_INPUT {
+        @Override
+        protected void notifyDigitalEvent(Object param, KonashiDigitalListener listener) {
+            listener.onUpdatePioInput(Byte.valueOf(param.toString()));
+        }
+    };
+
+    abstract protected void notifyDigitalEvent(Object param0, KonashiDigitalListener listener);
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        if (listener instanceof KonashiDigitalListener) {
+            notifyDigitalEvent(param0, (KonashiDigitalListener) listener);
+        }
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDigitalEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiDigitalEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 import com.uxxu.konashi.lib.listeners.KonashiDigitalListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiEvent.java
@@ -1,4 +1,4 @@
-package com.uxxu.konashi.lib;
+package com.uxxu.konashi.lib.events;
 
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiI2cEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiI2cEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 
 /**

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiI2cEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiI2cEvent.java
@@ -1,0 +1,19 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+
+/**
+ * Created by izumin on 8/7/15.
+ */
+public enum KonashiI2cEvent implements KonashiEvent {
+    /**
+     * I2Cからデータを受信した時
+     */
+    I2C_READ_COMPLETE;
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        // TODO: Not yet implemented.
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiUartEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiUartEvent.java
@@ -1,6 +1,5 @@
 package com.uxxu.konashi.lib.events;
 
-import com.uxxu.konashi.lib.KonashiEvent;
 import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
 import com.uxxu.konashi.lib.listeners.KonashiUartListener;
 

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiUartEvent.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/events/KonashiUartEvent.java
@@ -1,0 +1,29 @@
+package com.uxxu.konashi.lib.events;
+
+import com.uxxu.konashi.lib.KonashiEvent;
+import com.uxxu.konashi.lib.listeners.KonashiBaseListener;
+import com.uxxu.konashi.lib.listeners.KonashiUartListener;
+
+/**
+ * Created by izumin on 8/7/15.
+ */
+public enum KonashiUartEvent implements KonashiEvent {
+    /**
+     * UARTのRxからデータを受信した時
+     */
+    UART_RX_COMPLETE {
+        @Override
+        protected void notifyUartEvent(Object param, KonashiUartListener listener) {
+            listener.onCompleteUartRx((byte[]) param);
+        }
+    };
+
+    abstract protected void notifyUartEvent(Object param, KonashiUartListener listener);
+
+    @Override
+    public void notify(Object param0, Object param1, KonashiBaseListener listener) {
+        if (listener instanceof KonashiUartListener) {
+            notifyUartEvent(param0, (KonashiUartListener) listener);
+        }
+    }
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiAnalogListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiAnalogListener.java
@@ -1,0 +1,23 @@
+package com.uxxu.konashi.lib.listeners;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public interface KonashiAnalogListener extends KonashiBaseListener {
+    /**
+     * AIOのどれかのピンの電圧が取得できた時
+     */
+    void onUpdateAnalogValue(int pin, int value);
+    /**
+     * AIO0の電圧が取得できた時
+     */
+    void onUpdateAnalogValueAio0(int value);
+    /**
+     * AIO1の電圧が取得できた時
+     */
+    void onUpdateAnalogValueAio1(int value);
+    /**
+     * AIO2の電圧が取得できた時
+     */
+    void onUpdateAnalogValueAio2(int value);
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiBaseListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiBaseListener.java
@@ -1,0 +1,13 @@
+package com.uxxu.konashi.lib.listeners;
+
+import com.uxxu.konashi.lib.KonashiErrorReason;
+
+/**
+ * Created by izumin on 8/5/15.
+ */
+public interface KonashiBaseListener {
+    /**
+     * エラーが起きた時に呼ばれる
+     */
+    void onError(KonashiErrorReason errorReason, String message);
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiConnectionListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiConnectionListener.java
@@ -1,0 +1,27 @@
+package com.uxxu.konashi.lib.listeners;
+
+/**
+ * Created by izumin on 8/5/15.
+ */
+public interface KonashiConnectionListener extends KonashiBaseListener {
+    /**
+     * findWithNameで指定した名前のkonashiが見つからなかった時、もしくはまわりにBLEデバイスがなかった時に呼ばれる
+     */
+    void onNotFoundPeripheral();
+    /**
+     * konashiに接続した時(まだこの時はkonashiが使える状態ではありません)に呼ばれる
+     */
+    void onConnected();
+    /**
+     * konashiとの接続を切断した時に呼ばれる
+     */
+    void onDisconnected();
+    /**
+     * konashiに接続完了した時(この時からkonashiにアクセスできるようになります)に呼ばれる
+     */
+    void onReady();
+    /**
+     * BLEデバイス選択ダイアログをキャンセルした時に呼ばれる
+     */
+    void onCancelSelectKonashi();
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiDeviceInfoListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiDeviceInfoListener.java
@@ -1,0 +1,15 @@
+package com.uxxu.konashi.lib.listeners;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public interface KonashiDeviceInfoListener extends KonashiBaseListener {
+    /**
+     * konashiのバッテリーのレベルを取得できた時
+     */
+    void onUpdateBatteryLevel(int level);
+    /**
+     * konashiの電波強度を取得できた時
+     */
+    void onUpdateSignalStrength(int rssi);
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiDigitalListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiDigitalListener.java
@@ -1,0 +1,11 @@
+package com.uxxu.konashi.lib.listeners;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public interface KonashiDigitalListener extends KonashiBaseListener {
+    /**
+     * PIOの入力の状態が変化した時に呼ばれる
+     */
+    void onUpdatePioInput(byte value);
+}

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiListener.java
@@ -1,4 +1,4 @@
-package com.uxxu.konashi.lib;
+package com.uxxu.konashi.lib.listeners;
 
 import com.uxxu.konashi.lib.listeners.KonashiAnalogListener;
 import com.uxxu.konashi.lib.listeners.KonashiConnectionListener;

--- a/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiUartListener.java
+++ b/Konashi/konashi-v2-android-sdk/src/main/java/com/uxxu/konashi/lib/listeners/KonashiUartListener.java
@@ -1,0 +1,11 @@
+package com.uxxu.konashi.lib.listeners;
+
+/**
+ * Created by izumin on 8/6/15.
+ */
+public interface KonashiUartListener extends KonashiBaseListener {
+    /**
+     * UARTのRxからデータを受信した時
+     */
+    void onCompleteUartRx(byte[] data);
+}

--- a/apps/analog_test/src/main/java/com/uxxu/analog_test/MainActivity.java
+++ b/apps/analog_test/src/main/java/com/uxxu/analog_test/MainActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiErrorReason;
-import com.uxxu.konashi.lib.KonashiListener;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
 import com.uxxu.konashi.lib.ui.KonashiActivity;
 
 

--- a/apps/app/src/main/java/com/e10dokup/konashi_sdk_test/MainActivity.java
+++ b/apps/app/src/main/java/com/e10dokup/konashi_sdk_test/MainActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiErrorReason;
-import com.uxxu.konashi.lib.KonashiListener;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
 import com.uxxu.konashi.lib.ui.KonashiActivity;
 
 

--- a/apps/pwm_test/src/main/java/com/e10dokup/pwm_test/MainActivity.java
+++ b/apps/pwm_test/src/main/java/com/e10dokup/pwm_test/MainActivity.java
@@ -10,7 +10,7 @@ import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiErrorReason;
-import com.uxxu.konashi.lib.KonashiListener;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
 import com.uxxu.konashi.lib.ui.KonashiActivity;
 
 

--- a/apps/uart_tester/src/main/java/com/uxxu/konashi/uart_tester/MainActivity.java
+++ b/apps/uart_tester/src/main/java/com/uxxu/konashi/uart_tester/MainActivity.java
@@ -12,7 +12,7 @@ import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiErrorReason;
-import com.uxxu.konashi.lib.KonashiListener;
+import com.uxxu.konashi.lib.listeners.KonashiListener;
 import com.uxxu.konashi.lib.ui.KonashiActivity;
 
 


### PR DESCRIPTION
closed #28 
## WHY & WHAT
- `KonashiListener`の肥大化問題
  - AIOしか使わないのにUARTまわりのコールバックも書かないといけない など
- `KonashiNotifier`内でどのイベントのときどのコールバックメソッドを呼ぶかのハンドリングをしてた
  - イベントが増えたときにハンドリングを行う部分のコードの可読性が絶望的
  - 今後，大規模なイベント数増加が発生する可能性がある（#8, #12, #27, etc.）
## HOW
- listenerを用途別に分割，`KonashiListener`には従来通り全てのコールバックを持たせる
- イベントハンドリングを`KonashiNotifier`からイベント自身に行わせるように変更
