### PR TITLE
Bump version of gradle to 2.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip


### PR DESCRIPTION
#57

[android-maven-gradle-plugin](https://github.com/dcendents/android-maven-gradle-plugin) 1.3 require gradle version 2.3+.

> The following table shows the compatibility between the android-maven-gradle-plugin and gradle versions. It also lists the plugin name to use:
> 
> | Plugin Version | Plugin Name | Gradle Version |
> | --- | --- | --- |
> | 1.0 | android-maven | 1.8+ |
> | 1.1 | android-maven | 1.12+ |
> | 1.2 | com.github.dcendents.android-maven | 2.2+ |
> | 1.3 | com.github.dcendents.android-maven | 2.4+ |
> 
> https://github.com/dcendents/android-maven-gradle-plugin#note-on-releases
