### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # konashi SDK for Android
 [![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/s/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
+[![Download](https://api.bintray.com/packages/konashi-dev/maven/konashi-android-sdk/images/download.svg)](https://bintray.com/konashi-dev/maven/konashi-android-sdk/_latestVersion)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # konashi SDK for Android
-[![wercker status](https://app.wercker.com/status/976eb8c14c7b24a59c5c1e1a3d42ecbf/m "wercker status")](https://app.wercker.com/project/bykey/976eb8c14c7b24a59c5c1e1a3d42ecbf)
+[![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/s/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
 
 ---
 


### PR DESCRIPTION
Werckerのbadgeが古いやつのまま壊れてたので置き換え．
ついでにbintrayにアップしてるやつのバージョン番号も表示させてみた．
![image](https://cloud.githubusercontent.com/assets/2010175/9355018/2c91d1ec-46b0-11e5-8d4e-dea37c4b257d.png)
