### PR TITLE
Feature/better test report for wercker

### DIFF
--- a/.wercker/report.py
+++ b/.wercker/report.py
@@ -1,0 +1,45 @@
+import sys
+import os
+import StringIO
+import xml.etree.ElementTree as ET
+
+def main():
+    assert 1 < len(sys.argv)
+    path = sys.argv[1]
+    tree = None
+    with open(path) as f:
+        source = ''.join(f.readlines()[1:]) + '</html>'
+        print source
+        html = StringIO.StringIO(source)
+        tree = ET.parse(html)
+    if not tree:
+        print('Failed to load html')
+        return
+    root = tree.getroot()
+    contents = root.find('body').find('div')
+
+    summary_group = (contents.findall('div')[0]  # #summary
+                     .find('table').find('tr').find('td').find('div'))  # #summaryGroup
+
+    summary = dict([(td.find('div').find('p').text,
+                     td.find('div').find('div').text)
+                    for td in summary_group.find('table').find('tr').findall('td')])
+    print('=' * 80)
+    print(' | '.join(['{}: {}'.format(k, v) for k, v in summary.items()]))
+    print('=' * 80)
+
+    if int(summary['failures']) == 0:
+        return
+
+    print('Failures')
+    print('-' * 20)
+    class_tr_list = (contents
+                     .findall('div')[1]  # #tabs
+                     .findall('div')[0]  # #tab0
+                     .find('ul').find('table').findall('tr'))
+    for tr in class_tr_list:
+        method = '#'.join([td.find('a').text for td in tr.findall('td')])
+        print(method)
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 [![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/s/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
 [![Download](https://api.bintray.com/packages/konashi-dev/maven/konashi-android-sdk/images/download.svg)](https://bintray.com/konashi-dev/maven/konashi-android-sdk/_latestVersion)
 
-master | develop
------- | ----
-[![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/m/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241) | [![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/m/develop "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
-
 ---
 
 <img src="http://konashi.ux-xu.com/img/documents/i2c.png" width="600" />

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 [![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/s/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
 [![Download](https://api.bintray.com/packages/konashi-dev/maven/konashi-android-sdk/images/download.svg)](https://bintray.com/konashi-dev/maven/konashi-android-sdk/_latestVersion)
 
+master | develop
+------ | ----
+[![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/m/master "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241) | [![wercker status](https://app.wercker.com/status/6617295015c7f7518afc67a3182bd241/m/develop "wercker status")](https://app.wercker.com/project/bykey/6617295015c7f7518afc67a3182bd241)
+
 ---
 
 <img src="http://konashi.ux-xu.com/img/documents/i2c.png" width="600" />

--- a/wercker.yml
+++ b/wercker.yml
@@ -23,3 +23,5 @@ build:
           pwd
           ls -la ./konashi-android-sdk/build/outputs/
           cp -r ./konashi-android-sdk/build/outputs/* ${WERCKER_REPORT_ARTIFACTS_DIR}
+          REPORT_INDEX=/pipeline/build/konashi-android-sdk/build/reports/androidTests/connected/index.html
+          python .wercker/report.py $REPORT_INDEX


### PR DESCRIPTION
wercker 上のテスト結果出力がわかりづらいので python でスクレイピングしたわかりやすいテストレポートを _inspect build result_ に出力するようにしました。
出力結果は以下の様になります。

```
$ python .wercker/report.py $REPORT_INDEX
<html>
....
</body></html>
================================================================================
duration: 11.791s | failures: 0 | tests: 105
================================================================================
```

※ #91 の再申請です
