### PR TITLE
Bump version of Bletia to 1.3.0

### DIFF
--- a/konashi-android-sdk/build.gradle
+++ b/konashi-android-sdk/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'info.izumin.android:bletia:1.2.4'
+    compile 'info.izumin.android:bletia:1.3.0'
 
     androidTestCompile 'com.android.support.test:runner:0.3'
     androidTestCompile 'com.android.support.test:rules:0.3'

--- a/konashi-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiManagerTest.java
+++ b/konashi-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/KonashiManagerTest.java
@@ -9,7 +9,6 @@ import com.uxxu.konashi.lib.action.AioAnalogReadAction;
 import com.uxxu.konashi.lib.action.BatteryLevelReadAction;
 import com.uxxu.konashi.lib.action.HardwareResetAction;
 import com.uxxu.konashi.lib.action.I2cModeAction;
-import com.uxxu.konashi.lib.action.I2cReadAction;
 import com.uxxu.konashi.lib.action.I2cSendConditionAction;
 import com.uxxu.konashi.lib.action.I2cSetReadParamAction;
 import com.uxxu.konashi.lib.action.I2cWriteAction;
@@ -31,18 +30,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.mockito.verification.VerificationMode;
 
 import java.util.UUID;
 
 import info.izumin.android.bletia.Bletia;
 import info.izumin.android.bletia.BletiaException;
 import info.izumin.android.bletia.action.Action;
-import info.izumin.android.bletia.action.ReadRemoteRssiAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -58,22 +56,24 @@ public class KonashiManagerTest extends AndroidTestCase {
     public static final String TAG = KonashiManagerTest.class.getSimpleName();
 
     @Mock private BluetoothGattService mService;
+    @Mock private BluetoothGattCharacteristic mCharacteristic;
     @Mock private Bletia mBletia;
     @Spy private KonashiManager mKonashiManager;
 
-    private Deferred<BluetoothGattCharacteristic, BletiaException, Object> mDeferred;
-    private Promise<BluetoothGattCharacteristic, BletiaException, Object> mPromise;
+    private Deferred<BluetoothGattCharacteristic, BletiaException, Void> mDeferred;
+    private Promise<BluetoothGattCharacteristic, BletiaException, Void> mPromise;
 
-    private ArgumentCaptor<Action> mActionCaptor;
+    @Captor private ArgumentCaptor<Action<BluetoothGattCharacteristic, UUID>> mActionCaptor;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         mKonashiManager = new KonashiManager();
-        mActionCaptor = ArgumentCaptor.forClass(Action.class);
         mDeferred = new DeferredObject<>();
         mPromise = mDeferred.promise();
         when(mBletia.getService(any(UUID.class))).thenReturn(mService);
+        when(mService.getCharacteristic(any(UUID.class))).thenReturn(mCharacteristic);
+        when(mCharacteristic.getUuid()).thenReturn(UUID.randomUUID());
         when(mBletia.execute(mActionCaptor.capture())).thenReturn(mPromise);
         Whitebox.setInternalState(mKonashiManager, "mBletia", mBletia);
     }

--- a/konashi-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/action/AioAnalogReadActionTest.java
+++ b/konashi-android-sdk/src/androidTest/java/com/uxxu/konashi/lib/action/AioAnalogReadActionTest.java
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 
 import com.uxxu.konashi.lib.Konashi;
+import com.uxxu.konashi.lib.KonashiErrorType;
 import com.uxxu.konashi.lib.KonashiUUID;
 
 import org.junit.Before;
@@ -33,12 +34,12 @@ public class AioAnalogReadActionTest {
     @Test
     public void actionCharacteristic_InvalidPinNumber() throws Exception{
         mAction = new AioAnalogReadAction(mService, 5);
-        assertThat(mAction.getCharacteristic()).isNull();
+        assertThat(mAction.validate()).isEqualTo(KonashiErrorType.INVALID_PIN_NUMBER);
     }
 
     @Test
     public void actionCharacteristic_ValidPinNumber() throws Exception{
         mAction = new AioAnalogReadAction(mService, Konashi.AIO0);
-        assertThat(mAction.getCharacteristic()).isNotNull();
+        assertThat(mAction.validate()).isEqualTo(KonashiErrorType.NO_ERROR);
     }
 }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
@@ -191,7 +191,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin 設定するPIOのピン名。
      * @param mode ピンに設定するモード。INPUT か OUTPUT が設定できます。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pinMode(int pin, int mode){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pinMode(int pin, int mode){
         return execute(new PioPinModeAction(getKonashiService(), pin, mode, mPioStore.getModes()), mPioDispatcher);
     }
     
@@ -199,7 +199,7 @@ public class KonashiManager extends KonashiBaseManager {
      * PIOのピンを入力として使うか、出力として使うかの設定を行う
      * @param modes PIO0 〜 PIO7 の計8ピンの設定
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pinModeAll(int modes){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pinModeAll(int modes){
         return execute(new PioPinModeAction(getKonashiService(), modes), mPioDispatcher);
     }
     
@@ -208,7 +208,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin 設定するPIOのピン名
      * @param pullup ピンをプルアップするかの設定。PULLUP か NO_PULLS が設定できます。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pinPullup(int pin, int pullup){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pinPullup(int pin, int pullup){
         return execute(new PioPinPullupAction(getKonashiService(), pin, pullup, mPioStore.getPullups()), mPioDispatcher);
     }
     
@@ -216,7 +216,7 @@ public class KonashiManager extends KonashiBaseManager {
      * PIOのピンをプルアップするかの設定を行う
      * @param pullups PIO0 〜 PIO7 の計8ピンのプルアップの設定
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pinPullupAll(int pullups){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pinPullupAll(int pullups){
         return execute(new PioPinPullupAction(getKonashiService(), pullups), mPioDispatcher);
     }
     
@@ -242,7 +242,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin 設定するPIOのピン名
      * @param output 設定するPIOの出力状態。HIGH もしくは LOW が指定可能
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> digitalWrite(int pin, int output){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> digitalWrite(int pin, int output){
         return execute(new PioDigitalWriteAction(getKonashiService(), pin, output, mPioStore.getOutputs()), mPioDispatcher);
     }
     
@@ -250,7 +250,7 @@ public class KonashiManager extends KonashiBaseManager {
      * PIOの特定のピンの出力状態を設定する
      * @param outputs PIOの出力状態。PIO0〜PIO7の出力状態が8bit(1byte)で表現
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> digitalWriteAll(int outputs){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> digitalWriteAll(int outputs){
         return execute(new PioDigitalWriteAction(getKonashiService(), outputs), mPioDispatcher);
     }
     
@@ -264,19 +264,19 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin PWMモードの設定をするPIOのピン番号。Konashi.PIO0 〜 Konashi.PIO7。
      * @param mode 設定するPWMのモード。Konashi.PWM_DISABLE, Konashi.PWM_ENABLE, Konashi.PWM_ENABLE_LED_MODE のいずれかをセットする。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pwmMode(final int pin, int mode){
-        Promise<BluetoothGattCharacteristic, BletiaException, Object> promise =
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pwmMode(final int pin, int mode){
+        Promise<BluetoothGattCharacteristic, BletiaException, Void> promise =
                 execute(new PwmPinModeAction(getKonashiService(), pin, mode, mPwmStore.getModes())).then(mPwmDispatcher);
 
         if (mode == Konashi.PWM_ENABLE_LED_MODE) {
-            promise.then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+            promise.then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                 @Override
-                public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                     return pwmPeriod(pin, Konashi.PWM_LED_PERIOD).then(mPwmDispatcher);
                 }
-            }).then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+            }).then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                 @Override
-                public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                     return pwmLedDrive(pin, 0.0f).then(mPwmDispatcher);
                 }
             });
@@ -290,7 +290,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin PWMモードの設定をするPIOのピン番号。Konashi.PIO0 〜 Konashi.PIO7。
      * @param period 周期。単位はマイクロ秒(us)で32bitで指定してください。最大2^(32)us = 71.5分。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pwmPeriod(int pin, int period){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pwmPeriod(int pin, int period){
         return execute(new PwmPeriodAction(getKonashiService(), pin, period, mPwmStore.getDuty(pin))).then(mPwmDispatcher);
     }
     
@@ -299,7 +299,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin PWMモードの設定をするPIOのピン番号。Konashi.PIO0 〜 Konashi.PIO7。
      * @param duty デューティ。単位はマイクロ秒(us)で32bitで指定してください。最大2^(32)us = 71.5分。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pwmDuty(int pin, int duty){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pwmDuty(int pin, int duty){
         return execute(new PwmDutyAction(getKonashiService(), pin, duty, mPwmStore.getPeriod(pin))).then(mPwmDispatcher);
     }
     
@@ -308,7 +308,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin PWMモードの設定をするPIOのピン番号。Konashi.PIO0 〜 Konashi.PIO7。
      * @param dutyRatio LEDの明るさ。0.0F〜100.0F をしてしてください。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pwmLedDrive(int pin, float dutyRatio){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pwmLedDrive(int pin, float dutyRatio){
         return execute(new PwmLedDriveAction(getKonashiService(), pin, dutyRatio, mPwmStore.getPeriod(pin))).then(mPwmDispatcher);
     }
     
@@ -317,7 +317,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param pin PWMモードの設定をするPIOのピン番号。Konashi.PIO0 〜 Konashi.PIO7。
      * @param dutyRatio LEDの明るさ。0.0〜100.0 をしてしてください。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pwmLedDrive(int pin, double dutyRatio){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pwmLedDrive(int pin, double dutyRatio){
         return pwmLedDrive(pin, (float) dutyRatio);
     }
     
@@ -330,7 +330,7 @@ public class KonashiManager extends KonashiBaseManager {
      * AIO の指定のピンの入力電圧を取得する
      * @param pin AIOのピン名。指定可能なピン名は AIO0, AIO1, AIO2
      */
-    public Promise<Integer, BletiaException, Object> analogRead(final int pin) {
+    public Promise<Integer, BletiaException, Void> analogRead(final int pin) {
         return execute(new AioAnalogReadAction(getKonashiService(), pin))
                 .then(mAioDispatcher)
                 .then(new AioAnalogReadFilter(pin));
@@ -370,7 +370,7 @@ public class KonashiManager extends KonashiBaseManager {
      * UART の有効/無効を設定する
      * @param mode 設定するUARTのモード。Konashi.UART_DISABLE, Konashi.UART_ENABLE を指定
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> uartMode(int mode){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> uartMode(int mode){
         return execute(new UartModeAction(getKonashiService(), mode, mUartStore), mUartDispatcher);
     }
     
@@ -378,7 +378,7 @@ public class KonashiManager extends KonashiBaseManager {
      * UART の通信速度を設定する
      * @param baudrate UARTの通信速度。Konashi.UART_RATE_2K4 か Konashi.UART_RATE_9K6 を指定
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> uartBaudrate(int baudrate){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> uartBaudrate(int baudrate){
         return execute(new UartBaudrateAction(getKonashiService(), baudrate, mUartStore), mUartDispatcher);
     }
 
@@ -386,7 +386,7 @@ public class KonashiManager extends KonashiBaseManager {
      * UART でデータを送信する
      * @param bytes 送信するデータ(byte[])
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> uartWrite(byte[] bytes) {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> uartWrite(byte[] bytes) {
         return execute(new UartWriteAction(getKonashiService(), bytes, mUartStore));
     }
 
@@ -394,7 +394,7 @@ public class KonashiManager extends KonashiBaseManager {
      * UART でデータを送信する
      * @param string 送信するデータ(string)
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> uartWrite(String string) {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> uartWrite(String string) {
         return execute(new UartWriteAction(getKonashiService(), string, mUartStore), mUartDispatcher);
     }
 
@@ -429,7 +429,7 @@ public class KonashiManager extends KonashiBaseManager {
      * I2Cのコンディションを発行する
      * @param condition コンディション。Konashi.I2C_START_CONDITION, Konashi.I2C_RESTART_CONDITION, Konashi.I2C_STOP_CONDITION を指定できる。
      */
-    private Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cSendCondition(int condition) {
+    private Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cSendCondition(int condition) {
         return execute(new I2cSendConditionAction(getKonashiService(), condition, mI2cStore));
     }
 
@@ -437,28 +437,28 @@ public class KonashiManager extends KonashiBaseManager {
      * I2Cを有効/無効を設定する
      * @param mode 設定するI2Cのモード。Konashi.I2C_DISABLE , Konashi.I2C_ENABLE, Konashi.I2C_ENABLE_100K, Konashi.I2C_ENABLE_400Kを指定。
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cMode(int mode) {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cMode(int mode) {
         return execute(new I2cModeAction(getKonashiService(), mode, mI2cStore), mI2cDispatcher);
     }
 
     /**
      * I2Cのスタートコンディションを発行する
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cStartCondition() {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cStartCondition() {
         return i2cSendCondition(Konashi.I2C_START_CONDITION);
     }
 
     /**
      * I2Cのリスタートコンディションを発行する
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cRestartCondition() {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cRestartCondition() {
         return i2cSendCondition(Konashi.I2C_RESTART_CONDITION);
     }
 
     /**
      * I2Cのストップコンディションを発行する
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cStopCondition() {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cStopCondition() {
         return i2cSendCondition(Konashi.I2C_STOP_CONDITION);
     }
 
@@ -468,7 +468,7 @@ public class KonashiManager extends KonashiBaseManager {
      * @param data 書き込むデータの配列
      * @param address 書き込み先アドレス
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> i2cWrite(int length, byte[] data, byte address) {
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> i2cWrite(int length, byte[] data, byte address) {
         return execute(new I2cWriteAction(getKonashiService(), address, data, mI2cStore));
     }
 
@@ -477,12 +477,12 @@ public class KonashiManager extends KonashiBaseManager {
      * @param length 読み込むデータの長さ。最大 Konashi.I2C_DATA_MAX_LENGTHs (19)
      * @param address 読み込み先のアドレス
      */
-    public Promise<byte[], BletiaException, Object> i2cRead(int length, byte address) {
+    public Promise<byte[], BletiaException, Void> i2cRead(int length, byte address) {
         return execute(new I2cSetReadParamAction(getKonashiService(), length, address, mI2cStore))
                 .then(mI2cDispatcher)
-                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                     @Override
-                    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                         return execute(new I2cReadAction(getKonashiService()));
                     }
                 })
@@ -496,7 +496,7 @@ public class KonashiManager extends KonashiBaseManager {
     /**
      * konashiをリセットする
      */
-    public Promise<BluetoothGattCharacteristic, BletiaException, Object> reset(){
+    public Promise<BluetoothGattCharacteristic, BletiaException, Void> reset(){
         return execute(new HardwareResetAction(getKonashiService()));
     }
 
@@ -504,7 +504,7 @@ public class KonashiManager extends KonashiBaseManager {
      * konashi のバッテリ残量を取得
      * @return 0 〜 100 のパーセント単位でバッテリ残量が返る
      */
-    public Promise<Integer, BletiaException, Object> getBatteryLevel(){
+    public Promise<Integer, BletiaException, Void> getBatteryLevel(){
         return execute(new BatteryLevelReadAction(getService(KonashiUUID.BATTERY_SERVICE_UUID)))
                 .then(new BatteryLevelReadFilter());
     }
@@ -513,7 +513,7 @@ public class KonashiManager extends KonashiBaseManager {
      * konashi の電波強度を取得
      * @return 電波強度(単位はdb)
      */
-    public Promise<Integer, BletiaException, Object> getSignalStrength() {
+    public Promise<Integer, BletiaException, Void> getSignalStrength() {
         return mBletia.readRemoteRssi();
     }
 
@@ -522,11 +522,11 @@ public class KonashiManager extends KonashiBaseManager {
         mBletia.connect(device);
     }
 
-    private <T> Promise<T, BletiaException, Object> execute(Action<T> action, DoneCallback<T> callback) {
+    private <T> Promise<T, BletiaException, Void> execute(Action<T, ?> action, DoneCallback<T> callback) {
         return execute(action).then(callback);
     }
 
-    private <T> Promise<T, BletiaException, Object> execute(Action<T> action) {
+    private <T> Promise<T, BletiaException, Void> execute(Action<T, ?> action) {
         return mBletia.execute(action);
     }
 

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/AioAnalogReadAction.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/AioAnalogReadAction.java
@@ -10,7 +10,6 @@ import com.uxxu.konashi.lib.KonashiUUID;
 
 import java.util.UUID;
 
-import info.izumin.android.bletia.BleErrorType;
 import info.izumin.android.bletia.BletiaException;
 import info.izumin.android.bletia.action.ReadCharacteristicAction;
 import info.izumin.android.bletia.wrapper.BluetoothGattWrapper;
@@ -44,6 +43,6 @@ public class AioAnalogReadAction extends ReadCharacteristicAction {
     }
 
     private void rejectIfParamsAreInvalid() {
-        getDeferred().reject(new BletiaException(KonashiErrorType.INVALID_PIN_NUMBER, getCharacteristic()));
+        getDeferred().reject(new BletiaException(this, KonashiErrorType.INVALID_PIN_NUMBER));
     }
 }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/I2cAction.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/I2cAction.java
@@ -29,7 +29,7 @@ public abstract class I2cAction extends KonashiWriteCharacteristicAction {
         if (mStore.isEnabled() || mIsTypeMode) {
             super.execute(gattWrapper);
         } else {
-            getDeferred().reject(new BletiaException(KonashiErrorType.NOT_ENABLED_I2C));
+            getDeferred().reject(new BletiaException(this, KonashiErrorType.NOT_ENABLED_I2C));
         }
     }
 }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/KonashiWriteCharacteristicAction.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/KonashiWriteCharacteristicAction.java
@@ -37,7 +37,7 @@ public abstract class KonashiWriteCharacteristicAction extends WriteCharacterist
     }
 
     protected void rejectIfParamsAreInvalid(BletiaErrorType errorType) {
-        getDeferred().reject(new BletiaException(errorType, getCharacteristic()));
+        getDeferred().reject(new BletiaException(this, errorType));
     }
 
     protected abstract void setValue();

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/UartAction.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/UartAction.java
@@ -32,7 +32,7 @@ public abstract class UartAction extends KonashiWriteCharacteristicAction{
         if(mStore.getMode() == Konashi.UART_ENABLE || mIsTypeMode) {
             super.execute(gattWrapper);
         } else {
-            getDeferred().reject(new BletiaException(KonashiErrorType.NOT_ENABLED_UART));
+            getDeferred().reject(new BletiaException(this, KonashiErrorType.NOT_ENABLED_UART));
         }
     }
 }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/AioUtils.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/AioUtils.java
@@ -10,6 +10,10 @@ public final class AioUtils {
         throw new AssertionError("constructor of the utility class should not be called");
     }
 
+    public static boolean isValidPin(int pin) {
+        return (pin == Konashi.AIO0) || (pin == Konashi.AIO1) || (pin == Konashi.AIO2);
+    }
+
     public static int getAnalogValue(int pin, byte[] value) {
         switch (pin) {
             case Konashi.AIO0:

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/CommunicationFragment.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/CommunicationFragment.java
@@ -3,7 +3,6 @@ package com.uxxu.konashi.test_all_functions;
 import android.app.Fragment;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,13 +13,10 @@ import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.Switch;
-import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiListener;
 import com.uxxu.konashi.lib.KonashiManager;
-import com.uxxu.konashi.lib.KonashiUtils;
-import com.uxxu.konashi.lib.util.UartUtils;
 
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DonePipe;
@@ -158,9 +154,9 @@ public final class CommunicationFragment extends Fragment {
                 mKonashiManager.i2cMode(Konashi.I2C_ENABLE_100K);
 
                 mKonashiManager.i2cStartCondition()
-                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                     @Override
-                    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                         /*String text = mI2cDataEditText.getText().toString().trim();
                         if (Konashi.I2C_DATA_MAX_LENGTH < text.length()) {
                             text = text.substring(0, Konashi.I2C_DATA_MAX_LENGTH);
@@ -181,9 +177,9 @@ public final class CommunicationFragment extends Fragment {
                         mKonashiManager.i2cStartCondition();
                     }
                 })
-                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                     @Override
-                    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                 /*String text = mI2cDataEditText.getText().toString().trim();
                 if (Konashi.I2C_DATA_MAX_LENGTH < text.length()) {
                     text = text.substring(0, Konashi.I2C_DATA_MAX_LENGTH);
@@ -204,9 +200,9 @@ public final class CommunicationFragment extends Fragment {
                         mKonashiManager.i2cStartCondition();
                     }
                 })
-                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+                .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                     @Override
-                    public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                    public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                         byte[] data2 = {0x32};
                         return mKonashiManager.i2cWrite(1, data2, (byte) 0x53);
                     }
@@ -227,9 +223,9 @@ public final class CommunicationFragment extends Fragment {
             @Override
             public void onClick(View view) {
                 mKonashiManager.i2cStartCondition()
-                        .then(new DonePipe<BluetoothGattCharacteristic, byte[], BletiaException, Object>() {
+                        .then(new DonePipe<BluetoothGattCharacteristic, byte[], BletiaException, Void>() {
                             @Override
-                            public Promise<byte[], BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                            public Promise<byte[], BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                                 return mKonashiManager.i2cRead(6, (byte) 0x53);
                             }
                         })
@@ -267,9 +263,9 @@ public final class CommunicationFragment extends Fragment {
         }
         if (mUartSwitch.isChecked()) {
             mKonashiManager.uartMode(Konashi.UART_ENABLE)
-            .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Object>() {
+            .then(new DonePipe<BluetoothGattCharacteristic, BluetoothGattCharacteristic, BletiaException, Void>() {
                 @Override
-                public Promise<BluetoothGattCharacteristic, BletiaException, Object> pipeDone(BluetoothGattCharacteristic result) {
+                public Promise<BluetoothGattCharacteristic, BletiaException, Void> pipeDone(BluetoothGattCharacteristic result) {
                     int i = mUartBaudrateSpinner.getSelectedItemPosition();
                     String[] labels = getResources().getStringArray(R.array.uart_baudrates_labels);
                     String label = labels[i];


### PR DESCRIPTION
Bletia側のアップデート内容
- Improve BletiaException API
  - `BletiaException`のAPI改善: エラー発生元クラス名が取得できるようになった
- Call onDisconnect() when the status is GATT_FAILURE => #110
  - `onConnectionStateChange()`でdisconnectedかつfailureのときも`onDisconnect()`を呼ぶように変更
- Improve performance of queueing action
  - Actionのキューイング周りのパフォーマンス改善
- Modify 3rd type param: Object -> Void
  - Promiseのtype parameterの3つめをVoidに変更（呼ばれることがないので）
