### PR TITLE
Add unit testing using Groovy/Spock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:0.3.6'

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.3.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:0.3.6'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/konashi-android-sdk/build.gradle
+++ b/konashi-android-sdk/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'groovyx.grooid.groovy-android'
 
 def versionMajor = 1
 def versionMinor = 0

--- a/konashi-android-sdk/build.gradle
+++ b/konashi-android-sdk/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'com.squareup.assertj:assertj-android:1.0.1'
+
+    testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
 }
 
 

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/PwmUtils.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/PwmUtils.java
@@ -23,11 +23,11 @@ public final class PwmUtils {
     }
 
     public static boolean isValidPeriod(int period, int duty) {
-        return duty <= period;
+        return (period >= 0) && (duty >= 0) && (duty <= period);
     }
 
     public static boolean isValidDuty(int duty, int period) {
-        return duty <= period;
+        return isValidPeriod(period, duty);
     }
 
     public static boolean isValidDutyRatio(float dutyRatio) {

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/UartUtils.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/util/UartUtils.java
@@ -43,7 +43,7 @@ public final class UartUtils {
      * @return
      */
     public static boolean isValidLength(int length) {
-        return length > 0 && length <= (Konashi.UART_DATA_MAX_LENGTH + 1);
+        return length >= 0 && length <= (Konashi.UART_DATA_MAX_LENGTH + 1);
     }
 
     public static boolean isLengthTooShort(int length) {

--- a/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/AioUtilsTest.groovy
+++ b/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/AioUtilsTest.groovy
@@ -1,0 +1,29 @@
+package com.uxxu.konashi.lib.util
+
+import spock.lang.Specification
+
+class AioUtilsTest extends Specification {
+    def ".isValidPin"() {
+        expect:
+        AioUtils.isValidPin(pin) == result
+
+        where:
+        pin | result
+        -1  | false
+        0   | true
+        1   | true
+        2   | true
+        3   | false
+    }
+
+    def ".getAnalogValue()"() {
+        expect:
+        AioUtils.getAnalogValue(pin, value) == result
+
+        where:
+        pin | value                     || result
+        0   | [0x03, 0xe8] as byte[]    || 1000
+        1   | [0x00, 0x64] as byte[]    || 100
+        2   | [0x27, 0x10] as byte[]    || 10000
+    }
+}

--- a/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/I2cUtilsTest.groovy
+++ b/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/I2cUtilsTest.groovy
@@ -1,0 +1,70 @@
+package com.uxxu.konashi.lib.util;
+
+import spock.lang.Specification;
+
+/**
+ * Created by izumin on 10/7/15.
+ */
+class I2cUtilsTest extends Specification {
+    def ".isValidMode()"() {
+        expect:
+        I2cUtils.isValidMode(mode) == result
+
+        where:
+        mode    | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | true
+        3       | false
+    }
+
+    def ".isValidCondition()"() {
+        expect:
+        I2cUtils.isValidCondition(condition) == result
+
+        where:
+        condition   | result
+        -1          | false
+        0           | true
+        1           | true
+        2           | true
+        3           | false
+    }
+
+    def ".isValidDataLength()"() {
+        expect:
+        I2cUtils.isValidDataLength(length) == result
+
+        where:
+        length  | result
+        0       | false
+        1       | true
+        16      | true
+        17      | false
+    }
+
+    def ".isTooShortDataLength()"() {
+        expect:
+        I2cUtils.isTooShortDataLength(length) == result
+
+        where:
+        length  | result
+        0       | true
+        1       | false
+        16      | false
+        17      | false
+    }
+
+    def ".isTooLongDataLength()"() {
+        expect:
+        I2cUtils.isTooLongDataLength(length) == result
+
+        where:
+        length  | result
+        0       | false
+        1       | false
+        16      | false
+        17      | true
+    }
+}

--- a/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/PioUtilsTest.groovy
+++ b/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/PioUtilsTest.groovy
@@ -1,0 +1,104 @@
+package com.uxxu.konashi.lib.util
+
+import spock.lang.Specification;
+
+/**
+ * Created by izumin on 10/7/15.
+ */
+class PioUtilsTest extends Specification {
+    def ".isValidPin()"() {
+        expect:
+        PioUtils.isValidPin(pin) == result
+
+        where:
+        pin | result
+        -1  | false
+        0   | true
+        1   | true
+        2   | true
+        3   | true
+        4   | true
+        5   | true
+        6   | true
+        7   | true
+        8   | false
+    }
+
+    def ".isValidMode()"() {
+        expect:
+        PioUtils.isValidMode(mode) == result
+
+        where:
+        mode    | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | false
+    }
+
+    def ".isValidModes()"() {
+        expect:
+        PioUtils.isValidModes(modes) == result
+
+        where:
+        modes   | result
+        -0x01   | false
+        0x00    | true
+        0x04    | true
+        0xaa    | true
+        0xff    | true
+        0x100   | false
+    }
+
+    def ".isValidPullup()"() {
+        expect:
+        PioUtils.isValidPullup(pullup) == result
+
+        where:
+        pullup  | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | false
+    }
+
+    def ".isValidPullups()"() {
+        expect:
+        PioUtils.isValidPullups(pullups) == result
+
+        where:
+        pullups | result
+        -0x01   | false
+        0x00    | true
+        0x04    | true
+        0xaa    | true
+        0xff    | true
+        0x100   | false
+    }
+
+    def ".isValidOutput()"() {
+        expect:
+        PioUtils.isValidOutput(output) == result
+
+        where:
+        output  | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | false
+    }
+
+    def ".isValidOutputs()"() {
+        expect:
+        PioUtils.isValidOutputs(outputs) == result
+
+        where:
+        outputs | result
+        -0x01   | false
+        0x00    | true
+        0x04    | true
+        0xaa    | true
+        0xff    | true
+        0x100   | false
+    }
+}

--- a/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/PwmUtilsTest.groovy
+++ b/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/PwmUtilsTest.groovy
@@ -1,0 +1,101 @@
+package com.uxxu.konashi.lib.util;
+
+import spock.lang.Specification;
+
+/**
+ * Created by izumin on 10/7/15.
+ */
+class PwmUtilsTest extends Specification {
+    def ".isValidPin()"() {
+        expect:
+        PwmUtils.isValidPin(pin) == result
+
+        where:
+        pin | result
+        -1  | false
+        0   | true
+        1   | true
+        2   | true
+        3   | false
+    }
+
+    def ".isValidMode()"() {
+        expect:
+        PwmUtils.isValidMode(mode) == result
+
+        where:
+        mode    | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | true
+        3       | false
+    }
+
+    def ".isValidPeriod()"() {
+        expect:
+        PwmUtils.isValidPeriod(period, duty) == result
+
+        where:
+        period  | duty  || result
+        0       | 0     || true
+        1       | 0     || true
+        1       | 1     || true
+        0       | 1     || false
+        0       | -1    || false
+        -1      | 0     || false
+        -1      | -2    || false
+    }
+
+    def ".isValidDuty()"() {
+        expect:
+        PwmUtils.isValidDuty(duty, period) == result
+
+        where:
+        duty    | period    || result
+        0       | 0         || true
+        0       | 1         || true
+        1       | 0         || false
+        1       | 1         || true
+        -1      | 0         || false
+        0       | -1        || false
+        -2      | -1        || false
+    }
+
+    def ".isValidDutyRatio()"() {
+        expect:
+        PwmUtils.isValidDutyRatio(dutyRatio) == result;
+
+        where:
+        dutyRatio   | result
+        -1          | false
+        0           | true
+        50          | true
+        100         | true
+        101         | false
+    }
+
+    def ".getPwmDuty()"() {
+        expect:
+        PwmUtils.getPwmDuty(value) == result
+
+        where:
+        value                                       | result
+        [0x00, 0x00, 0x00, 0x00, 0x00] as byte[]    | 0
+        [0x01, 0x00, 0x00, 0x27, 0x10] as byte[]    | 10000
+        [0x02, 0x00, 0x01, 0x86, 0xa0] as byte[]    | 100000
+        [0x03, 0x00, 0x0f, 0x42, 0x40] as byte[]    | 1000000
+    }
+
+    def ".getPwmPeriod()"() {
+        expect:
+        PwmUtils.getPwmPeriod(value) == result
+
+        where:
+        value                                       | result
+        [0x00, 0x00, 0x00, 0x00, 0x00] as byte[]    | 0
+        [0x01, 0x00, 0x00, 0x27, 0x10] as byte[]    | 10000
+        [0x02, 0x00, 0x01, 0x86, 0xa0] as byte[]    | 100000
+        [0x03, 0x00, 0x0f, 0x42, 0x40] as byte[]    | 1000000
+    }
+}

--- a/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/UartUtilsTest.groovy
+++ b/konashi-android-sdk/src/test/groovy/com/uxxu/konashi/lib/util/UartUtilsTest.groovy
@@ -1,0 +1,92 @@
+package com.uxxu.konashi.lib.util
+
+import spock.lang.Specification
+/**
+ * Created by izumin on 10/7/15.
+ */
+class UartUtilsTest extends Specification {
+    def ".isValidBaudrate()"() {
+        expect:
+        UartUtils.isValidBaudrate(baudrate) == result
+
+        where:
+        baudrate    | result
+        -0x0001     | false
+        0x0000      | false
+        0x0001      | false
+        0x0028      | true
+        0x0050      | true
+        0x00a0      | true
+        0x00f0      | true
+        0x0140      | true
+        0x01e0      | true
+    }
+
+    def ".isValidMode()"() {
+        expect:
+        UartUtils.isValidMode(mode) == result
+
+        where:
+        mode    | result
+        -1      | false
+        0       | true
+        1       | true
+        2       | false
+    }
+
+    def ".toFormattedByteArray(String string)"() {
+        expect:
+        UartUtils.toFormattedByteArray(string) == result
+
+        where:
+        string  | result
+        ""      | [0] as byte[]
+        "test"  | [4, 0x74, 0x65, 0x73, 0x74] as byte[]
+    }
+
+    def ".toFormattedByteArray(byte[] bytes)"() {
+        expect:
+        UartUtils.toFormattedByteArray(bytes) == result
+
+        where:
+        bytes                               | result
+        [] as byte[]                        | [0] as byte[]
+        [0x74, 0x65, 0x73, 0x74] as byte[]  | [4, 0x74, 0x65, 0x73, 0x74] as byte[]
+    }
+
+    def ".isValidLength()"() {
+        expect:
+        UartUtils.isValidLength(length) == result
+
+        where:
+        length  | result
+        -1      | false
+        0       | true
+        19      | true
+        20      | false
+    }
+
+    def ".isLengthTooShort()"() {
+        expect:
+        UartUtils.isLengthTooShort(length) == result
+
+        where:
+        length  | result
+        -1      | true
+        0       | false
+        19      | false
+        20      | false
+    }
+
+    def ".isLengthTooLong()"() {
+        expect:
+        UartUtils.isLengthTooLong(length) == result
+
+        where:
+        length  | result
+        -1      | false
+        0       | false
+        19      | false
+        20      | true
+    }
+}

--- a/wercker.yml
+++ b/wercker.yml
@@ -11,7 +11,7 @@ build:
     - script:
         name: run gradle test
         code: |
-          gradle --full-stacktrace -q --project-cache-dir=$WERCKER_CACHE_DIR :konashi-android-sdk:test
+          gradle --full-stacktrace -info --project-cache-dir=$WERCKER_CACHE_DIR :konashi-android-sdk:test
     - script:
         name: start android emulator
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -9,6 +9,10 @@ build:
           echo $ANDROID_BUILD_TOOLS
           echo $ANDROID_UPDATE_FILTER
     - script:
+        name: run gradle test
+        code: |
+          gradle --full-stacktrace -q --project-cache-dir=$WERCKER_CACHE_DIR :konashi-android-sdk:test
+    - script:
         name: start android emulator
         code: |
           start-emulator


### PR DESCRIPTION
## WHY
- エミュレータや実機に繋ぐテスト（Instrumentation Test, connectedAndroidTest）がわりと重い
- Utility classのテストを書きたいが，JUnitではparameterized testが書きづらい
## HOW, WHAT

GroovyとそのテスティングフレームワークSpockを導入してUtility classの簡単なユニットテストを書いてみる．Spockには標準でPowerAssertっぽいのが入ってる，パラメタライズドテストが書きやすいといったメリットが存在し，これを導入することでテストにかかる工数の削減が期待できる．

また，テストをエミュレータに接続しないUnit testにすることで，高速にテストを実行できるようにする．
