### PR TITLE
Delete initialize at I2cSample

### DIFF
--- a/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
+++ b/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mSendEdit = (EditText) findViewById(R.id.edit_send);
         mResultText = (TextView) findViewById(R.id.text_read);
 
-        mKonashiManager = new KonashiManager(this);
+        mKonashiManager = new KonashiManager(getApplicationContext());
     }
 
     @Override

--- a/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
+++ b/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
@@ -43,14 +43,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mSendEdit = (EditText) findViewById(R.id.edit_send);
         mResultText = (TextView) findViewById(R.id.text_read);
 
-        mKonashiManager = new KonashiManager();
+        mKonashiManager = new KonashiManager(this);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         mKonashiManager.addListener(mKonashiListener);
-        mKonashiManager.initialize(this);
         refreshViews();
     }
 


### PR DESCRIPTION
I2Cのサンプルのみ `mKonashiManager.initialize()` が生き残っていたので削除
