### PR TITLE
Stop calling uartDispatcher after uartWrite(String)

### DIFF
--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
@@ -439,7 +439,7 @@ public class KonashiManager {
      * @param string 送信するデータ(string)
      */
     public Promise<BluetoothGattCharacteristic, BletiaException, Void> uartWrite(String string) {
-        return execute(new UartWriteAction(getKonashiService(), string, mUartStore), mUartDispatcher);
+        return execute(new UartWriteAction(getKonashiService(), string, mUartStore));
     }
 
     /**


### PR DESCRIPTION
Closes #147 

Fix to be thrown IllegalArgumentException by the callback of KonashiManager#uartWrite(String)
