### PR TITLE
Remove descriptor writing

### DIFF
--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 
+import com.uxxu.konashi.lib.action.KonashiEnableNotificationAction;
 import com.uxxu.konashi.lib.dispatcher.DispatcherContainer;
 import com.uxxu.konashi.lib.util.KonashiUtils;
 import com.uxxu.konashi.lib.util.SpiUtils;
@@ -50,13 +51,22 @@ class CallbackHandler implements BletiaListener {
 
     @Override
     public void onServicesDiscovered(Bletia bletia, int status) {
+//        if (status == BluetoothGatt.GATT_SUCCESS) {
+//            BluetoothGattService service = bletia.getService(KonashiUUID.KONASHI_SERVICE_UUID);
+//            bletia.enableNotification(service.getCharacteristic(KonashiUUID.PIO_INPUT_NOTIFICATION_UUID), true);
+//            bletia.enableNotification(service.getCharacteristic(KonashiUUID.UART_RX_NOTIFICATION_UUID), true);
+//            bletia.enableNotification(service.getCharacteristic(KonashiUUID.HARDWARE_LOW_BAT_NOTIFICATION_UUID), true);
+//            BluetoothGattCharacteristic spiCharacteristic = service.getCharacteristic(KonashiUUID.SPI_NOTIFICATION_UUID);
+//            if(spiCharacteristic != null) bletia.enableNotification(spiCharacteristic, true);
+//            mEmitter.emitConnect(mManager);
+//        }
         if (status == BluetoothGatt.GATT_SUCCESS) {
             BluetoothGattService service = bletia.getService(KonashiUUID.KONASHI_SERVICE_UUID);
-            bletia.enableNotification(service.getCharacteristic(KonashiUUID.PIO_INPUT_NOTIFICATION_UUID), true);
-            bletia.enableNotification(service.getCharacteristic(KonashiUUID.UART_RX_NOTIFICATION_UUID), true);
-            bletia.enableNotification(service.getCharacteristic(KonashiUUID.HARDWARE_LOW_BAT_NOTIFICATION_UUID), true);
+            bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.PIO_INPUT_NOTIFICATION_UUID), true));
+            bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.UART_RX_NOTIFICATION_UUID), true));
+            bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.HARDWARE_LOW_BAT_NOTIFICATION_UUID), true));
             BluetoothGattCharacteristic spiCharacteristic = service.getCharacteristic(KonashiUUID.SPI_NOTIFICATION_UUID);
-            if(spiCharacteristic != null) bletia.enableNotification(spiCharacteristic, true);
+            if(spiCharacteristic != null) bletia.execute(new KonashiEnableNotificationAction(spiCharacteristic, true));
             mEmitter.emitConnect(mManager);
         }
     }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/KonashiEnableNotificationAction.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/action/KonashiEnableNotificationAction.java
@@ -1,0 +1,50 @@
+package com.uxxu.konashi.lib.action;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattService;
+
+import java.util.UUID;
+
+import info.izumin.android.bletia.BleErrorType;
+import info.izumin.android.bletia.BletiaException;
+import info.izumin.android.bletia.action.Action;
+import info.izumin.android.bletia.action.EnableNotificationAction;
+import info.izumin.android.bletia.util.NotificationUtils;
+import info.izumin.android.bletia.wrapper.BluetoothGattWrapper;
+
+/**
+ * Created by e10dokup on 2016/07/21
+ **/
+public class KonashiEnableNotificationAction extends EnableNotificationAction {
+    private static final String TAG = KonashiEnableNotificationAction.class.getSimpleName();
+    private final KonashiEnableNotificationAction self = this;
+
+    public KonashiEnableNotificationAction(BluetoothGattService service, UUID uuid, boolean enabled) {
+        super(service, uuid, enabled);
+    }
+
+    public KonashiEnableNotificationAction(BluetoothGattCharacteristic characteristic, boolean enabled) {
+        super(characteristic, enabled);
+    }
+
+    @Override
+    public Type getType() {
+        return super.getType();
+    }
+
+    @Override
+    public boolean execute(BluetoothGattWrapper gattWrapper) {
+        if (gattWrapper.setCharacteristicNotification(getCharacteristic(), getEnabled())) {
+            return true;
+        } else {
+            getDeferred().reject(new BletiaException(this, BleErrorType.REQUEST_FAILURE));
+            return false;
+        }
+    }
+
+    @Override
+    public boolean getEnabled() {
+        return super.getEnabled();
+    }
+}


### PR DESCRIPTION
# Purpose

Android6.0以上の端末でkonashiに接続する際，descriptorのwriteを実行するところまでは大丈夫だがそのコールバックである `onDescriptorWrite` が全く発火せずdeviceがビジー状態に陥り，notification以外のすべての操作ができなくなっていたので，descriptorのwriteの処理を排除する必要があった

恐らく，Android6.0未満では失敗していながら何故か `onDescriptorWrite` が発火していたのがAndroid6.0修正された結果のもの
# change log
- 独自にdescriptorのwrite処理を行わない `KonashiNotificationEnableAction` を実装
- `CallbackHandler#onServiceDiscovered` 内のNotification enablingの処理を `KonashiNotificationEnableAction` に移譲
