### PR TITLE
Add lintOption abortOnError

### DIFF
--- a/konashi-android-sdk/build.gradle
+++ b/konashi-android-sdk/build.gradle
@@ -35,6 +35,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Wercker上でdeployが実行されるとgradle buildが以下の状態でfailする

![2016-07-21 17 04 36](https://cloud.githubusercontent.com/assets/5158413/17015469/4cd1c4c6-4f65-11e6-8585-164c4de7779e.png)

とりあえずlintのabortOnErrorをenableにしましたが，他の方法でなんとかなるのであればcloseお願いします．
