### PR TITLE
Implement callback on fail finding and connecting

### DIFF
--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
@@ -62,6 +62,9 @@ class CallbackHandler implements BletiaListener {
 //        }
         if (status == BluetoothGatt.GATT_SUCCESS) {
             BluetoothGattService service = bletia.getService(KonashiUUID.KONASHI_SERVICE_UUID);
+            if (service == null) {
+                mEmitter.emitConnectOtherDevice(mManager);
+            }
             bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.PIO_INPUT_NOTIFICATION_UUID), true));
             bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.UART_RX_NOTIFICATION_UUID), true));
             bletia.execute(new KonashiEnableNotificationAction(service.getCharacteristic(KonashiUUID.HARDWARE_LOW_BAT_NOTIFICATION_UUID), true));

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/ConnectionHelper.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/ConnectionHelper.java
@@ -125,6 +125,9 @@ class ConnectionHelper implements BleDeviceSelectionDialog.OnBleDeviceSelectList
                 mIsScanning = false;
                 if (mKonashiName == null) {
                     mDialog.finishFinding();
+                } else {
+                    // findWithNameした時にデバイスが見つけられなかったとき
+                    mCallback.onFindNoDevice();
                 }
             }
         }
@@ -132,5 +135,6 @@ class ConnectionHelper implements BleDeviceSelectionDialog.OnBleDeviceSelectList
 
     public interface Callback {
         void onSelectBleDevice(BluetoothDevice device);
+        void onFindNoDevice();
     }
 }

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/EventEmitter.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/EventEmitter.java
@@ -37,6 +37,17 @@ class EventEmitter extends ArrayList<KonashiListener> {
         });
     }
 
+    public void emitConnectOtherDevice(final KonashiManager manager) {
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                for (KonashiListener listener : self) {
+                    listener.onConnectOtherDevice(manager);
+                }
+            }
+        });
+    }
+
     public void emitDisconnect(final KonashiManager manager) {
         mHandler.post(new Runnable() {
             @Override

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/EventEmitter.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/EventEmitter.java
@@ -26,6 +26,17 @@ class EventEmitter extends ArrayList<KonashiListener> {
         });
     }
 
+    public void emitFindNoDevice(final KonashiManager manager) {
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                for (KonashiListener listener : self) {
+                    listener.onFindNoDevice(manager);
+                }
+            }
+        });
+    }
+
     public void emitDisconnect(final KonashiManager manager) {
         mHandler.post(new Runnable() {
             @Override

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
@@ -7,6 +7,7 @@ import info.izumin.android.bletia.BletiaException;
  */
 public interface KonashiListener {
     void onConnect(KonashiManager manager);
+    void onFindNoDevice(KonashiManager manager);
     void onDisconnect(KonashiManager manager);
     void onError(KonashiManager manager, BletiaException e);
     void onUpdatePioOutput(KonashiManager manager, int value);

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiListener.java
@@ -8,6 +8,7 @@ import info.izumin.android.bletia.BletiaException;
 public interface KonashiListener {
     void onConnect(KonashiManager manager);
     void onFindNoDevice(KonashiManager manager);
+    void onConnectOtherDevice(KonashiManager manager);
     void onDisconnect(KonashiManager manager);
     void onError(KonashiManager manager, BletiaException e);
     void onUpdatePioOutput(KonashiManager manager, int value);

--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/KonashiManager.java
@@ -702,5 +702,10 @@ public class KonashiManager {
         public void onSelectBleDevice(BluetoothDevice device) {
             connect(device);
         }
+
+        @Override
+        public void onFindNoDevice() {
+            mEmitter.emitFindNoDevice(KonashiManager.this);
+        }
     };
 }

--- a/samples/aio-sample/src/main/java/com/uxxu/konashi/sample/aiosample/MainActivity.java
+++ b/samples/aio-sample/src/main/java/com/uxxu/konashi/sample/aiosample/MainActivity.java
@@ -126,6 +126,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onError(KonashiManager manager, BletiaException e) {
 
         }

--- a/samples/aio-sample/src/main/java/com/uxxu/konashi/sample/aiosample/MainActivity.java
+++ b/samples/aio-sample/src/main/java/com/uxxu/konashi/sample/aiosample/MainActivity.java
@@ -7,10 +7,12 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.uxxu.konashi.lib.Konashi;
 import com.uxxu.konashi.lib.KonashiListener;
 import com.uxxu.konashi.lib.KonashiManager;
+import com.uxxu.konashi.lib.util.KonashiUtils;
 
 import org.jdeferred.DoneCallback;
 
@@ -109,6 +111,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         @Override
         public void onConnect(KonashiManager manager) {
             refreshViews();
+        }
+
+        @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
         }
 
         @Override

--- a/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
+++ b/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
@@ -165,6 +165,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
+++ b/samples/i2c-sample/src/main/java/com/uxxu/konashi/sample/i2csample/MainActivity.java
@@ -158,6 +158,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/pio-sample/src/main/java/com/uxxu/konashi/sample/piosample/MainActivity.java
+++ b/samples/pio-sample/src/main/java/com/uxxu/konashi/sample/piosample/MainActivity.java
@@ -113,6 +113,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/pio-sample/src/main/java/com/uxxu/konashi/sample/piosample/MainActivity.java
+++ b/samples/pio-sample/src/main/java/com/uxxu/konashi/sample/piosample/MainActivity.java
@@ -120,6 +120,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/pwm-sample/src/main/java/com/uxxu/konashi/sample/pwmsample/MainActivity.java
+++ b/samples/pwm-sample/src/main/java/com/uxxu/konashi/sample/pwmsample/MainActivity.java
@@ -128,6 +128,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/pwm-sample/src/main/java/com/uxxu/konashi/sample/pwmsample/MainActivity.java
+++ b/samples/pwm-sample/src/main/java/com/uxxu/konashi/sample/pwmsample/MainActivity.java
@@ -121,6 +121,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/spi-sample/src/main/java/com/uxxu/konashi/sample/spisample/MainActivity.java
+++ b/samples/spi-sample/src/main/java/com/uxxu/konashi/sample/spisample/MainActivity.java
@@ -160,6 +160,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/spi-sample/src/main/java/com/uxxu/konashi/sample/spisample/MainActivity.java
+++ b/samples/spi-sample/src/main/java/com/uxxu/konashi/sample/spisample/MainActivity.java
@@ -153,6 +153,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/CommunicationFragment.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/CommunicationFragment.java
@@ -304,6 +304,8 @@ public final class CommunicationFragment extends Fragment {
     private final KonashiListener mKonashiListener = new KonashiListener() {
         @Override public void onConnect(KonashiManager manager) {}
         @Override public void onDisconnect(KonashiManager manager) {}
+        @Override public void onFindNoDevice(KonashiManager manager) {}
+        @Override public void onConnectOtherDevice(KonashiManager manager) {}
         @Override public void onError(KonashiManager manager, BletiaException e) {}
         @Override public void onUpdatePioOutput(KonashiManager manager, int value) {}
         @Override public void onUpdateSpiMiso(KonashiManager manager, byte[] value) {}

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/MainActivity.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/MainActivity.java
@@ -227,6 +227,15 @@ public class MainActivity extends AppCompatActivity
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            KonashiUtils.log("onConnectedOtherDevice");
+            refreshActionBarMenu();
+            mOverlay.setVisibility(View.VISIBLE);
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             KonashiUtils.log("onDisconnected");
             refreshActionBarMenu();

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/MainActivity.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/MainActivity.java
@@ -218,6 +218,15 @@ public class MainActivity extends AppCompatActivity
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            KonashiUtils.log("onFindNoDevice");
+            refreshActionBarMenu();
+            mOverlay.setVisibility(View.VISIBLE);
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             KonashiUtils.log("onDisconnected");
             refreshActionBarMenu();

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/PioFragment.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/PioFragment.java
@@ -87,6 +87,8 @@ public final class PioFragment extends Fragment {
     private final KonashiListener mKonashiListener = new KonashiListener() {
         @Override public void onConnect(KonashiManager manager) {}
         @Override public void onDisconnect(KonashiManager manager) {}
+        @Override public void onFindNoDevice(KonashiManager manager) {}
+        @Override public void onConnectOtherDevice(KonashiManager manager) {}
         @Override public void onError(KonashiManager manager, BletiaException e) {}
 
         @Override

--- a/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/SpiFragment.java
+++ b/samples/test_all_functions/src/main/java/com/uxxu/konashi/test_all_functions/SpiFragment.java
@@ -3,7 +3,6 @@ package com.uxxu.konashi.test_all_functions;
 import android.app.Fragment;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -203,6 +202,8 @@ public final class SpiFragment extends Fragment {
     private final KonashiListener mKonashiListener = new KonashiListener() {
         @Override public void onConnect(KonashiManager manager) {}
         @Override public void onDisconnect(KonashiManager manager) {}
+        @Override public void onFindNoDevice(KonashiManager manager) {}
+        @Override public void onConnectOtherDevice(KonashiManager manager) {}
         @Override public void onError(KonashiManager manager, BletiaException e) {}
         @Override public void onUpdatePioOutput(KonashiManager manager, int value) {}
         @Override public void onUpdateUartRx(KonashiManager manager, byte[] value) {}

--- a/samples/uart-sample/src/main/java/com/uxxu/konashi/sample/uartsample/MainActivity.java
+++ b/samples/uart-sample/src/main/java/com/uxxu/konashi/sample/uartsample/MainActivity.java
@@ -130,6 +130,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onFindNoDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Find No Konashi Devices", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }

--- a/samples/uart-sample/src/main/java/com/uxxu/konashi/sample/uartsample/MainActivity.java
+++ b/samples/uart-sample/src/main/java/com/uxxu/konashi/sample/uartsample/MainActivity.java
@@ -137,6 +137,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
 
         @Override
+        public void onConnectOtherDevice(KonashiManager manager) {
+            refreshViews();
+
+            Toast.makeText(MainActivity.this, "Connected Device is not Konashi", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
         public void onDisconnect(KonashiManager manager) {
             refreshViews();
         }


### PR DESCRIPTION
Related issues: #193 #72 

* KonashiManager#findWithNameで選択したkonashiが発見できなかったときにcallbackを発火するように仕様を変更
* KonashiManager#connectした際に検索できたserviceにkonashiのものが存在しなかった場合、callbackを発火するように仕様を変更