### PR TITLE
emitConnet must be fired after spi-notification is enabled

### DIFF
--- a/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
+++ b/konashi-android-sdk/src/main/java/com/uxxu/konashi/lib/CallbackHandler.java
@@ -112,8 +112,18 @@ class CallbackHandler implements BletiaListener {
             @Override
             public void onDone(BluetoothGattCharacteristic bluetoothGattCharacteristic) {
                 BluetoothGattCharacteristic spiCharacteristic = service.getCharacteristic(KonashiUUID.SPI_NOTIFICATION_UUID);
-                if(spiCharacteristic != null) bletia.execute(new KonashiEnableNotificationAction(spiCharacteristic, true));
-                mEmitter.emitConnect(mManager);
+                if(spiCharacteristic != null) {
+                    bletia.execute(new KonashiEnableNotificationAction(spiCharacteristic, true))
+                        .done(new DoneCallback<BluetoothGattCharacteristic>() {
+                            @Override
+                            public void onDone(BluetoothGattCharacteristic characteristic) {
+                                mEmitter.emitConnect(mManager);
+                            }
+                        });
+                } else {
+                    mEmitter.emitConnect(mManager);
+                }
+
             }
         }).fail(new FailCallback<BletiaException>() {
             @Override


### PR DESCRIPTION
SPIが実装されているkonashiにおいて、接続完了を示すemitConnectがSPIのNotificationのEnabledが完了する前に発火されていたため、emitConnectのコールバック内で即座にcharacteristicに操作を行うと拒否される問題に対応しました